### PR TITLE
Extracting a Job.Action interface

### DIFF
--- a/library/src/androidTest/java/com/evernote/android/job/test/JobManagerTest.java
+++ b/library/src/androidTest/java/com/evernote/android/job/test/JobManagerTest.java
@@ -71,11 +71,15 @@ public class JobManagerTest {
         return JobManager.instance(InstrumentationRegistry.getContext());
     }
 
-    private static final class TestJob extends Job {
+    private static final class TestJob implements Job.Action {
+
         @NonNull
         @Override
-        protected Result onRunJob(@NonNull Params params) {
-            return Result.FAILURE;
+        public Job.Result onRunJob(@NonNull Job.Params params) {
+            return Job.Result.FAILURE;
         }
+
+        @Override
+        public void onReschedule(int newJobId) {}
     }
 }

--- a/library/src/androidTest/java/com/evernote/android/job/test/JobRequestTest.java
+++ b/library/src/androidTest/java/com/evernote/android/job/test/JobRequestTest.java
@@ -188,11 +188,15 @@ public class JobRequestTest {
         return new JobRequest.Builder(InstrumentationRegistry.getContext(), TestJob.class);
     }
 
-    private static final class TestJob extends Job {
+    private static final class TestJob implements Job.Action {
+
         @NonNull
         @Override
-        protected Result onRunJob(@NonNull Params params) {
-            return Result.FAILURE;
+        public Job.Result onRunJob(@NonNull Job.Params params) {
+            return Job.Result.FAILURE;
         }
+
+        @Override
+        public void onReschedule(int newJobId) {}
     }
 }

--- a/library/src/main/java/com/evernote/android/job/JobExecutor.java
+++ b/library/src/main/java/com/evernote/android/job/JobExecutor.java
@@ -55,10 +55,8 @@ import java.util.concurrent.TimeUnit;
 
     public synchronized Future<Job.Result> execute(@NonNull Context context, @NonNull JobRequest request) {
         try {
-            Job job = request.getJobClass()
-                    .newInstance()
-                    .setContext(context)
-                    .setRequest(request);
+            Job.Action action = request.getJobClass().newInstance();
+            Job job = new Job(action, context, request);
 
             Cat.i("Executing request %d, context %s", request.getJobId(), context.getClass().getSimpleName());
 
@@ -129,10 +127,8 @@ import java.util.concurrent.TimeUnit;
         }
 
         private void handleResult(Job.Result result) {
-            JobRequest request = mJob.getParams().getRequest();
-            if (!request.isPeriodic() && Job.Result.RESCHEDULE.equals(result)) {
-                int newJobId = request.reschedule(true);
-                mJob.onReschedule(newJobId);
+            if(result == Job.Result.RESCHEDULE) {
+                mJob.reschedule();
             }
         }
 

--- a/library/src/main/java/com/evernote/android/job/JobRequest.java
+++ b/library/src/main/java/com/evernote/android/job/JobRequest.java
@@ -85,7 +85,7 @@ public final class JobRequest {
     /**
      * @return The {@link Job} class which will run in the future.
      */
-    public Class<? extends Job> getJobClass() {
+    public Class<? extends Job.Action> getJobClass() {
         return mBuilder.mJobClass;
     }
 
@@ -303,7 +303,7 @@ public final class JobRequest {
     public static final class Builder {
 
         private final int mId;
-        private final Class<? extends Job> mJobClass;
+        private final Class<? extends Job.Action> mJobClass;
 
         private long mStartMs;
         private long mEndMs;
@@ -327,7 +327,7 @@ public final class JobRequest {
          *                it hasn't been done.
          * @param jobClass The endpoint that you implement that will receive the callback.
          */
-        public Builder(@NonNull Context context, @NonNull Class<? extends Job> jobClass) {
+        public Builder(@NonNull Context context, @NonNull Class<? extends Job.Action> jobClass) {
             mJobClass = JobPreconditions.checkNotNull(jobClass);
             mId = JobManager.instance(context).getJobStorage().nextJobId();
 
@@ -365,7 +365,7 @@ public final class JobRequest {
         @SuppressWarnings("unchecked")
         private Builder(PersistableBundleCompat bundle) throws Exception {
             mId = bundle.getInt("id", -1);
-            mJobClass = (Class<? extends Job>) Class.forName(bundle.getString("jobClass", null));
+            mJobClass = (Class<? extends Job.Action>) Class.forName(bundle.getString("jobClass", null));
 
             mStartMs = bundle.getLong("startMs", -1);
             mEndMs = bundle.getLong("endMs", -1);
@@ -584,7 +584,7 @@ public final class JobRequest {
          * @param backoffMs The initial interval to wait when the job has been rescheduled.
          * @param backoffPolicy Is either {@link BackoffPolicy#LINEAR} or {@link BackoffPolicy#EXPONENTIAL}.
          * @see Job.Result#RESCHEDULE
-         * @see Job#onReschedule(int)
+         * @see Job#reschedule()
          */
         public Builder setBackoffCriteria(long backoffMs, @NonNull BackoffPolicy backoffPolicy) {
             mBackoffMs = JobPreconditions.checkArgumentPositive(backoffMs, "backoffMs must be > 0");


### PR DESCRIPTION
This way, the action performed by the job is independent of the job
itself. The boundaries of the data accessible to the action is clearer
(only what is available in the `Params` object).

This also restricts the use of reflection to building the `Job.Action`
object. The job object is built with a simple `new`, and thus can be
passed some more parameters.

Also reduced the API of `Job`, in part by having it handle the
rescheduling on its own.
