### PR TITLE
Reschedule a job if the platform job isn't scheduled anymore

### DIFF
--- a/library/src/main/java/com/evernote/android/job/JobBootReceiver.java
+++ b/library/src/main/java/com/evernote/android/job/JobBootReceiver.java
@@ -30,11 +30,6 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.evernote.android.job.util.JobApi;
-import com.evernote.android.job.util.JobCat;
-
-import net.vrallev.android.cat.CatLog;
-
-import java.util.Set;
 
 /**
  * A {@code BroadcastReceiver} rescheduling jobs after a reboot, if the underlying {@link JobApi} can't
@@ -44,25 +39,12 @@ import java.util.Set;
  */
 public final class JobBootReceiver extends BroadcastReceiver {
 
-    private static final CatLog CAT = new JobCat("JobBootReceiver");
-
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (intent == null || !Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
-            return;
-        }
-
-        Set<JobRequest> requests = JobManager.instance().getAllJobRequests();
-
-        CAT.d("Schedule %d jobs if necessary", requests.size());
-
-        for (JobRequest request : requests) {
-            if (JobApi.V_14.equals(request.getJobApi())) {
-                // update execution window
-                request.cancelAndEdit()
-                        .build()
-                        .schedule();
-            }
-        }
+        /*
+         * We don't need to do anything. This receiver causes the app to be loaded. In the onCreate()
+         * method of the Application object we initialize the JobManager. There we reschedule tasks
+         * if necessary.
+         */
     }
 }

--- a/library/src/main/java/com/evernote/android/job/JobProxy.java
+++ b/library/src/main/java/com/evernote/android/job/JobProxy.java
@@ -53,6 +53,8 @@ public interface JobProxy {
 
     void cancel(JobRequest request);
 
+    boolean isPlatformJobScheduled(JobRequest request);
+
     /*package*/ final class Common {
 
         public static long getStartMs(JobRequest request) {

--- a/library/src/main/java/com/evernote/android/job/gcm/JobProxyGcm.java
+++ b/library/src/main/java/com/evernote/android/job/gcm/JobProxyGcm.java
@@ -98,6 +98,12 @@ public class JobProxyGcm implements JobProxy {
         mGcmNetworkManager.cancelTask(createTag(request), PlatformGcmService.class);
     }
 
+    @Override
+    public boolean isPlatformJobScheduled(JobRequest request) {
+        // there is no option to check whether a task is scheduled, assume it is
+        return true;
+    }
+
     protected String createTag(JobRequest request) {
         return String.valueOf(request.getJobId());
     }

--- a/library/src/main/java/com/evernote/android/job/v14/JobProxy14.java
+++ b/library/src/main/java/com/evernote/android/job/v14/JobProxy14.java
@@ -75,13 +75,22 @@ public class JobProxy14 implements JobProxy {
         mAlarmManager.cancel(getPendingIntent(request, request.isPeriodic()));
     }
 
-    protected PendingIntent getPendingIntent(JobRequest request, boolean repeating) {
-        Intent intent = PlatformAlarmReceiver.createIntent(request);
+    @Override
+    public boolean isPlatformJobScheduled(JobRequest request) {
+        PendingIntent pendingIntent = getPendingIntent(request, PendingIntent.FLAG_NO_CREATE);
+        return pendingIntent != null;
+    }
 
+    protected PendingIntent getPendingIntent(JobRequest request, boolean repeating) {
         int flags = PendingIntent.FLAG_UPDATE_CURRENT;
         if (!repeating) {
             flags |= PendingIntent.FLAG_ONE_SHOT;
         }
+        return getPendingIntent(request, flags);
+    }
+
+    protected PendingIntent getPendingIntent(JobRequest request, int flags) {
+        Intent intent = PlatformAlarmReceiver.createIntent(request);
 
         // repeating PendingIntent with service seams to have problems
         return PendingIntent.getBroadcast(mContext, request.getJobId(), intent, flags);

--- a/library/src/main/java/com/evernote/android/job/v21/JobProxy21.java
+++ b/library/src/main/java/com/evernote/android/job/v21/JobProxy21.java
@@ -40,6 +40,8 @@ import com.evernote.android.job.util.JobUtil;
 
 import net.vrallev.android.cat.CatLog;
 
+import java.util.List;
+
 
 /**
  * @author rwondratschek
@@ -93,6 +95,23 @@ public class JobProxy21 implements JobProxy {
     @Override
     public void cancel(JobRequest request) {
         mJobScheduler.cancel(request.getJobId());
+    }
+
+    @Override
+    public boolean isPlatformJobScheduled(JobRequest request) {
+        List<JobInfo> pendingJobs = mJobScheduler.getAllPendingJobs();
+        if (pendingJobs == null || pendingJobs.isEmpty()) {
+            return false;
+        }
+
+        int requestId = request.getJobId();
+        for (JobInfo info : pendingJobs) {
+            if (info.getId() == requestId) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected JobInfo.Builder createBaseBuilder(JobRequest request) {


### PR DESCRIPTION
This can happen, if you set an alarm with the AlarmManager and then force
close the app. This clears all alarms.
