### PR TITLE
remove reduplicate support-v4 library

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,6 +4,12 @@ apply from: '../build-config/gradle-quality.gradle'
 
 archivesBaseName = 'android-job'
 
+configurations.all {
+    resolutionStrategy {
+        force "com.android.support:support-v4:$supportLibVersion"
+    }
+}
+
 dependencies {
     provided "com.google.android.gms:play-services-gcm:$playServicesVersion"
 


### PR DESCRIPTION
Use `force` to remove the 24.0.0 version of support-v4 dependency. To make source code in AS more readable.