### PR TITLE
Fix JobService component disabled bug

### DIFF
--- a/library/src/main/java/com/evernote/android/job/JobRescheduleService.java
+++ b/library/src/main/java/com/evernote/android/job/JobRescheduleService.java
@@ -65,6 +65,9 @@ public final class JobRescheduleService extends IntentService {
 
             CAT.d("Reschedule %d jobs of %d jobs", rescheduledCount, requests.size());
 
+        } catch (Exception ignore) {
+            // IllegalArgumentException No such service ComponentInfo
+            // JobService component disabled by third party app on rooted devices
         } finally {
             WakeLockUtil.completeWakefulIntent(intent);
         }


### PR DESCRIPTION
IllegalArgumentException No such service ComponentInfo com.evernote.android.job.v21.PlatformJobService
JobService component disabled by third party app which has root permission on rooted devices