### PR TITLE
Fix a mistake in code sample.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ private void schedulePeriodicJob() {
 }
 
 private void scheduleExactJob() {
-    int jobId = new JobRequest.Builder(DemoSyncJob.class)
+    int jobId = new JobRequest.Builder(DemoSyncJob.TAG)
             .setExact(20_000L)
             .setPersisted(true)
             .build()


### PR DESCRIPTION
`JobRequest.Builder` only accepts `String` tag as a constructor parameter.