### PR TITLE
Nullability annotations on JobCreator

### DIFF
--- a/library/src/main/java/com/evernote/android/job/JobCreator.java
+++ b/library/src/main/java/com/evernote/android/job/JobCreator.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
  * A {@code JobCreator} maps a tag to a specific {@link Job} class. You need to pass the tag in the
@@ -31,7 +32,8 @@ public interface JobCreator {
      * and isn't rescheduled.
      * @see JobRequest.Builder#Builder(String)
      */
-    Job create(String tag);
+    @Nullable
+    Job create(@NonNull String tag);
 
     /**
      * Action to notify receives that the application was instantiated and {@link JobCreator}s should be added.


### PR DESCRIPTION
Using this library from a Kotlin context, it is nice for it to know that tag is always not null, and that the returned Job can be null 😄 