### PR TITLE
Make Params for onRunJob NonNull

### DIFF
--- a/library/src/main/java/com/evernote/android/job/Job.java
+++ b/library/src/main/java/com/evernote/android/job/Job.java
@@ -113,7 +113,7 @@ public abstract class Job {
      */
     @NonNull
     @WorkerThread
-    protected abstract Result onRunJob(Params params);
+    protected abstract Result onRunJob(@NonNull Params params);
 
     /*package*/ final Result runJob() {
         try {


### PR DESCRIPTION
This helps with Kotlin users to know that the Params will never be null (right?)