### PR TITLE
Add a method to convert PersistableBundleCompat to an Intent.

### DIFF
--- a/library/src/main/java/com/evernote/android/job/util/support/PersistableBundleCompat.java
+++ b/library/src/main/java/com/evernote/android/job/util/support/PersistableBundleCompat.java
@@ -25,11 +25,10 @@
  */
 package com.evernote.android.job.util.support;
 
+import android.content.Intent;
 import android.os.PersistableBundle;
 import android.support.annotation.NonNull;
-
 import com.evernote.android.job.util.JobCat;
-
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.ByteArrayInputStream;
@@ -251,6 +250,39 @@ public final class PersistableBundleCompat {
             } catch (IOException ignored) {
             }
         }
+    }
+
+    @NonNull
+    @SuppressWarnings("unchecked")
+    public Intent toIntent() {
+        Intent intent = new Intent();
+        for (String key : mValues.keySet()) {
+            Object value = get(key);
+            if (value != null) {
+                if (value instanceof Boolean) {
+                    intent.putExtra(key, (Boolean) value);
+                } else if (value instanceof Double) {
+                    intent.putExtra(key, (Double) value);
+                } else if (value instanceof double[]) {
+                    intent.putExtra(key, (double[]) value);
+                } else if (value instanceof Integer) {
+                    intent.putExtra(key, (Integer) value);
+                } else if (value instanceof int[]) {
+                    intent.putExtra(key, (int[]) value);
+                } else if (value instanceof Long) {
+                    intent.putExtra(key, (Long) value);
+                } else if (value instanceof long[]) {
+                    intent.putExtra(key, (long[]) value);
+                } else if (value instanceof String) {
+                    intent.putExtra(key, (String) value);
+                } else if (value instanceof String[]) {
+                    intent.putExtra(key, (String[]) value);
+                } else if (value instanceof Map) {
+                    intent.putExtra(key, new PersistableBundleCompat((Map<String, Object>) value).toIntent());
+                }
+            }
+        }
+        return intent;
     }
 
     @SuppressWarnings("unchecked")

--- a/library/src/test/java/com/evernote/android/job/util/support/PersistableBundleCompatTest.java
+++ b/library/src/test/java/com/evernote/android/job/util/support/PersistableBundleCompatTest.java
@@ -1,7 +1,7 @@
 package com.evernote.android.job.util.support;
 
+import android.content.Intent;
 import com.evernote.android.job.test.JobRobolectricTestRunner;
-
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,44 +15,73 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 @RunWith(JobRobolectricTestRunner.class)
 @FixMethodOrder(MethodSorters.JVM)
 public class PersistableBundleCompatTest {
+    private static final String EXTRA_BOOL_1 = "EXTRA_BOOL_1";
+    private static final String EXTRA_INT_1 = "EXTRA_INT_1";
+    private static final String EXTRA_LONG_1 = "EXTRA_LONG_1";
+    private static final String EXTRA_DOUBLE_1 = "EXTRA_DOUBLE_1";
+    private static final String EXTRA_STRING_1 = "EXTRA_STRING_1";
+    private static final String EXTRA_STRING_2 = "EXTRA_STRING_2";
+    private static final String EXTRA_INT_ARR = "EXTRA_INT_ARR";
+    private static final String EXTRA_LONG_ARR = "EXTRA_LONG_ARR";
+    private static final String EXTRA_DOUBLE_ARR = "EXTRA_DOUBLE_ARR";
+    private static final String EXTRA_STRING_ARR = "EXTRA_STRING_ARR";
+    private static final String EXTRA_BUNDLE_1 = "EXTRA_BUNDLE_1";
 
     @Test
     public void testBundle() {
         PersistableBundleCompat bundle = new PersistableBundleCompat();
-        bundle.putBoolean("bool1", true);
-        bundle.putInt("int1", 1);
-        bundle.putLong("long1", 1L);
-        bundle.putDouble("double1", 1.0);
-        bundle.putString("string1", "hello");
-        bundle.putIntArray("intArr", new int[]{1, 2, 3});
-        bundle.putLongArray("longArr", new long[]{4L, 5L, 6L});
-        bundle.putDoubleArray("doubleArr", new double[]{7.0, 8.0, 9.0});
-        bundle.putStringArray("stringArr", new String[]{"Hello", "world"});
+        bundle.putBoolean(EXTRA_BOOL_1, true);
+        bundle.putInt(EXTRA_INT_1, 1);
+        bundle.putLong(EXTRA_LONG_1, 1L);
+        bundle.putDouble(EXTRA_DOUBLE_1, 1.0);
+        bundle.putString(EXTRA_STRING_1, "hello");
+        bundle.putIntArray(EXTRA_INT_ARR, new int[]{1, 2, 3});
+        bundle.putLongArray(EXTRA_LONG_ARR, new long[]{4L, 5L, 6L});
+        bundle.putDoubleArray(EXTRA_DOUBLE_ARR, new double[]{7.0, 8.0, 9.0});
+        bundle.putStringArray(EXTRA_STRING_ARR, new String[]{"Hello", "world"});
 
         PersistableBundleCompat other = new PersistableBundleCompat();
-        other.putString("string2", "world");
-        bundle.putPersistableBundleCompat("bundle1", other);
+        other.putString(EXTRA_STRING_2, "world");
+        bundle.putPersistableBundleCompat(EXTRA_BUNDLE_1, other);
 
+        // test XML saves and inflates correctly
         String xml = bundle.saveToXml();
         PersistableBundleCompat inflated = PersistableBundleCompat.fromXml(xml);
 
         assertThat(xml).isNotEmpty();
         assertThat(inflated).isNotNull();
 
-        assertThat(inflated.getBoolean("bool1", false)).isTrue();
-        assertThat(inflated.getInt("int1", 0)).isEqualTo(1);
-        assertThat(inflated.getLong("long1", 0L)).isEqualTo(1L);
-        assertThat(inflated.getDouble("double1", 0.0)).isEqualTo(1.0);
-        assertThat(inflated.getString("string1", null)).isEqualTo("hello");
-        assertThat(inflated.getIntArray("intArr")).isNotEmpty().containsExactly(1, 2, 3);
-        assertThat(inflated.getLongArray("longArr")).isNotEmpty().containsExactly(4L, 5L, 6L);
-        assertThat(inflated.getDoubleArray("doubleArr")).isNotEmpty().containsExactly(7.0, 8.0, 9.0);
-        assertThat(inflated.getStringArray("stringArr")).isNotEmpty().containsExactly("Hello", "world");
+        assertThat(inflated.getBoolean(EXTRA_BOOL_1, false)).isTrue();
+        assertThat(inflated.getInt(EXTRA_INT_1, 0)).isEqualTo(1);
+        assertThat(inflated.getLong(EXTRA_LONG_1, 0L)).isEqualTo(1L);
+        assertThat(inflated.getDouble(EXTRA_DOUBLE_1, 0.0)).isEqualTo(1.0);
+        assertThat(inflated.getString(EXTRA_STRING_1, null)).isEqualTo("hello");
+        assertThat(inflated.getIntArray(EXTRA_INT_ARR)).isNotEmpty().containsExactly(1, 2, 3);
+        assertThat(inflated.getLongArray(EXTRA_LONG_ARR)).isNotEmpty().containsExactly(4L, 5L, 6L);
+        assertThat(inflated.getDoubleArray(EXTRA_DOUBLE_ARR)).isNotEmpty().containsExactly(7.0, 8.0, 9.0);
+        assertThat(inflated.getStringArray(EXTRA_STRING_ARR)).isNotEmpty().containsExactly("Hello", "world");
 
-
-        PersistableBundleCompat inflatedInner = inflated.getPersistableBundleCompat("bundle1");
+        PersistableBundleCompat inflatedInner = inflated.getPersistableBundleCompat(EXTRA_BUNDLE_1);
         assertThat(inflatedInner).isNotNull();
-        assertThat(inflatedInner.getString("string2", null)).isEqualTo("world");
+        assertThat(inflatedInner.getString(EXTRA_STRING_2, null)).isEqualTo("world");
+
+        // test that the Intent contains all the values from PersistableBundleCompat
+        Intent intent = bundle.toIntent();
+        assertThat(intent).isNotNull();
+
+        assertThat(intent.getBooleanExtra(EXTRA_BOOL_1, false)).isTrue();
+        assertThat(intent.getIntExtra(EXTRA_INT_1, 0)).isEqualTo(1);
+        assertThat(intent.getLongExtra(EXTRA_LONG_1, 0L)).isEqualTo(1L);
+        assertThat(intent.getDoubleExtra(EXTRA_DOUBLE_1, 0.0)).isEqualTo(1.0);
+        assertThat(intent.getStringExtra(EXTRA_STRING_1)).isEqualTo("hello");
+        assertThat(intent.getIntArrayExtra(EXTRA_INT_ARR)).isNotEmpty().containsExactly(1, 2, 3);
+        assertThat(intent.getLongArrayExtra(EXTRA_LONG_ARR)).isNotEmpty().containsExactly(4L, 5L, 6L);
+        assertThat(intent.getDoubleArrayExtra(EXTRA_DOUBLE_ARR)).isNotEmpty().containsExactly(7.0, 8.0, 9.0);
+        assertThat(intent.getStringArrayExtra(EXTRA_STRING_ARR)).isNotEmpty().containsExactly("Hello", "world");
+
+        Intent innerIntent = intent.getParcelableExtra(EXTRA_BUNDLE_1);
+        assertThat(innerIntent).isNotNull();
+        assertThat(innerIntent.getStringExtra(EXTRA_STRING_2)).isEqualTo("world");
     }
 
     @Test


### PR DESCRIPTION
There are cases where we'd want to convert the `PersistableBundleCompat` to an `Intent` to make the code simpler (rather than duplicate the code for both types of `Bundle`s).