### PR TITLE
Configured Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,10 @@
+container:
+  image: cirrusci/android-sdk:27
+
+check_android_task:
+  gradle_cache:
+    folder: ~/.gradle/caches
+  check_script: ./gradlew check --info
+  cleanup_before_caching_script:
+    - rm -fr ~/.gradle/caches/4.*
+    - find ~/.gradle/caches/ -name "*.lock" -type f -delete

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
 #VERSION_NAME=1.2.3
 VERSION_NAME=1.2.3-SNAPSHOT
 VERSION_CODE=1
+
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,15 @@
 include ':demo', ':library'
+
+ext.isCiServer = System.getenv().containsKey("CI")
+ext.isMasterBranch = System.getenv()["CIRRUS_BRANCH"] == "master"
+
+buildCache {
+    local {
+        enabled = !isCiServer
+    }
+    remote(HttpBuildCache) {
+        url = 'http://' + System.getenv().getOrDefault("CIRRUS_HTTP_CACHE_HOST", "localhost:12321") + "/"
+        enabled = isCiServer
+        push = isMasterBranch
+    }
+}


### PR DESCRIPTION
When there are tests it's good to run them

Configured according to https://cirrus-ci.org/examples/#android

Similar to https://github.com/evernote/android-state/pull/40 but CI is failing right now because of https://github.com/evernote/android-job/issues/369 which I can reproduce even locally.

![image](https://user-images.githubusercontent.com/989066/35879508-65802b9c-0b49-11e8-97a1-527ca613adbc.png)

I'll try to dig more into failing of `BackoffCriteriaTests`...

Please don't forget to [install Cirrus CI](https://github.com/apps/cirrus-ci) on the repository before merging.