### PR TITLE
Update proguard.cfg

### DIFF
--- a/library/proguard.cfg
+++ b/library/proguard.cfg
@@ -6,3 +6,4 @@
 -keep public class com.evernote.android.job.v14.PlatformAlarmReceiver
 -keep public class com.evernote.android.job.JobBootReceiver
 -keep public class com.evernote.android.job.JobRescheduleService
+-keep public class com.evernote.android.job.gcm.PlatformGcmService.java

--- a/library/proguard.cfg
+++ b/library/proguard.cfg
@@ -6,4 +6,4 @@
 -keep public class com.evernote.android.job.v14.PlatformAlarmReceiver
 -keep public class com.evernote.android.job.JobBootReceiver
 -keep public class com.evernote.android.job.JobRescheduleService
--keep public class com.evernote.android.job.gcm.PlatformGcmService.java
+-keep public class com.evernote.android.job.gcm.PlatformGcmService


### PR DESCRIPTION
should keep com.evernote.android.job.gcm.PlatformGcmService,because manifest have a clear definition.