### PR TITLE
Fixed Bug Where Alarm Fails After App is Killed

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
             android:name="com.evernote.android.job.v14.PlatformAlarmReceiver"
             android:exported="false">
             <intent-filter>
+                <action android:name="com.evernote.android.job.v14.ALARM_ALERT"/>
                 <!-- Keep the filter for legacy intents -->
                 <action android:name="com.evernote.android.job.v14.RUN_JOB"/>
                 <action android:name="net.vrallev.android.job.v14.RUN_JOB"/>

--- a/library/src/main/java/com/evernote/android/job/v14/PlatformAlarmReceiver.java
+++ b/library/src/main/java/com/evernote/android/job/v14/PlatformAlarmReceiver.java
@@ -38,12 +38,13 @@ import com.evernote.android.job.JobProxy;
  */
 public class PlatformAlarmReceiver extends BroadcastReceiver {
 
+    /*package*/ static final String ALARM_ALERT_FILTER = "com.evernote.android.job.v14.ALARM_ALERT";
     /*package*/ static final String EXTRA_JOB_ID = "EXTRA_JOB_ID";
     /*package*/ static final String EXTRA_JOB_EXACT = "EXTRA_JOB_EXACT";
     /*package*/ static final String EXTRA_TRANSIENT_EXTRAS = "EXTRA_TRANSIENT_EXTRAS";
 
     /*package*/ static Intent createIntent(Context context, int jobId, boolean exact, @Nullable Bundle transientExtras) {
-        Intent intent = new Intent(context, PlatformAlarmReceiver.class).putExtra(EXTRA_JOB_ID, jobId).putExtra(EXTRA_JOB_EXACT, exact);
+        Intent intent = new Intent(ALARM_ALERT_FILTER).putExtra(EXTRA_JOB_ID, jobId).putExtra(EXTRA_JOB_EXACT, exact);
         if (transientExtras != null) {
             intent.putExtra(EXTRA_TRANSIENT_EXTRAS, transientExtras);
         }


### PR DESCRIPTION
A while back, someone made [an issue about how exact jobs do not work after the app is killed or removed from the recent task list](https://github.com/evernote/android-job/issues/354). He then reported that this issue goes away after the app is whitelisted in battery optimization. However, this is only a possible solution on [Android 6.0+](https://www.verizonwireless.com/support/knowledge-base-202636/). On the other hand, I had an Android 5.1 and I still experienced this problem, so I could not use this solution.

Therefore, in order to fix this problem, I made the `Intent` for `PlatformAlarmReceiver` implicit, using a custom intent filter, so that it does not get canceled after the app is killed. This allows the alarms to continue going off even after the app is killed.