### PR TITLE
Declare JobManager#mJobStorage a volatile field, see #492

### DIFF
--- a/library/src/main/java/com/evernote/android/job/JobManager.java
+++ b/library/src/main/java/com/evernote/android/job/JobManager.java
@@ -140,7 +140,7 @@ public final class JobManager {
     private final JobCreatorHolder mJobCreatorHolder;
     private final JobExecutor mJobExecutor;
 
-    private JobStorage mJobStorage;
+    private volatile JobStorage mJobStorage;
     private final CountDownLatch mJobStorageLatch;
 
     private JobManager(final Context context) {


### PR DESCRIPTION
See https://github.com/evernote/android-job/issues/492.