### PR TITLE
Extending crash fix for Android 4.x with recent Google Play Services to cancel() method…

### DIFF
--- a/library/src/main/java/com/evernote/android/job/gcm/JobProxyGcm.java
+++ b/library/src/main/java/com/evernote/android/job/gcm/JobProxyGcm.java
@@ -101,7 +101,15 @@ public class JobProxyGcm implements JobProxy {
 
     @Override
     public void cancel(int jobId) {
-        mGcmNetworkManager.cancelTask(createTag(jobId), PlatformGcmService.class);
+        try {
+            mGcmNetworkManager.cancelTask(createTag(jobId), PlatformGcmService.class);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage() != null && e.getMessage().startsWith("The GcmTaskService class you provided")) {
+                throw new JobProxyIllegalStateException(e);
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
According this [comment](https://github.com/evernote/android-job/issues/415#issuecomment-408112831) on issue #415, the library stills crashing when cancel() is called. I just extended the same fix on scheduleTask() to cancel(), so an IllegalArgumentException with "The GcmTaskService class you provided" will become a JobProxyIllegalStateException.