### PR TITLE
Should not auto enable PlatformGcmService in Android 4.x to avoid crash in ca…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
@@ -11,8 +11,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     tasks.withType(JavaCompile) {

--- a/library/src/androidTest/java/com/evernote/android/job/PlatformJobManagerRule.java
+++ b/library/src/androidTest/java/com/evernote/android/job/PlatformJobManagerRule.java
@@ -39,7 +39,10 @@ public class PlatformJobManagerRule extends ExternalResource {
         mManager.cancelAll();
         mManager.destroy();
 
-        getJobScheduler().cancelAll();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getJobScheduler().cancelAll();
+        }
+
         JobConfig.reset();
     }
 

--- a/library/src/androidTest/java/com/evernote/android/job/PlatformTest.java
+++ b/library/src/androidTest/java/com/evernote/android/job/PlatformTest.java
@@ -159,6 +159,23 @@ public class PlatformTest {
         assertThat(mManager.getJobRequest(jobId)).isNull();
     }
 
+    @Test
+    public void testUpdateCurrent() {
+        String TAG = "tag";
+
+        JobRequest.Builder builder = new JobRequest.Builder(TAG)
+                .setUpdateCurrent(true)
+                .setExecutionWindow(TimeUnit.HOURS.toMillis(4), TimeUnit.HOURS.toMillis(5));
+
+        builder.build().schedule();
+
+        assertThat(JobManager.instance().getAllJobRequestsForTag(TAG)).hasSize(1);
+
+        builder.build().schedule();
+
+        assertThat(JobManager.instance().getAllJobRequestsForTag(TAG)).hasSize(1);
+    }
+
     private final class TestJob extends Job {
 
         private final CountDownLatch mLatch = new CountDownLatch(1);

--- a/library/src/main/java/com/evernote/android/job/GcmAvailableHelper.java
+++ b/library/src/main/java/com/evernote/android/job/GcmAvailableHelper.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.os.Build;
 import android.support.annotation.RestrictTo;
 
 import com.evernote.android.job.gcm.JobProxyGcm;
@@ -58,7 +59,7 @@ import java.util.List;
 
     public static boolean isGcmApiSupported(Context context) {
         try {
-            if (!checkedServiceEnabled) {
+            if (!checkedServiceEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 checkedServiceEnabled = true;
                 setServiceEnabled(context, GCM_IN_CLASSPATH);
             }


### PR DESCRIPTION
…ncel() method

For fixing #415 in some 4.x devices

```
com.evernote.android.job.JobProxyIllegalStateException: java.lang.IllegalArgumentException: The GcmTaskService class you provided com.evernote.android.job.gcm.PlatformGcmService does not seem to support receiving com.google.android.gms.gcm.ACTION_TASK_READY
at com.evernote.android.job.gcm.JobProxyGcm.cancel(JobProxyGcm.java:108)
at com.evernote.android.job.JobManager.cancelInner(JobManager.java:401)
at com.evernote.android.job.JobManager.cancelAllInner(JobManager.java:424)
at com.evernote.android.job.JobManager.cancelAll(JobManager.java:385)
...
Caused by: java.lang.IllegalArgumentException: The GcmTaskService class you provided com.evernote.android.job.gcm.PlatformGcmService does not seem to support receiving com.google.android.gms.gcm.ACTION_TASK_READY
at com.google.android.gms.gcm.GcmNetworkManager.zze(Unknown Source)
at com.google.android.gms.gcm.GcmNetworkManager.cancelTask(Unknown Source)
at com.evernote.android.job.gcm.JobProxyGcm.cancel(JobProxyGcm.java:105)
```

This error was reported on the devices with Android 4.x below:

**Samsung:**
SM-G530H
SM-N900
SM-N7507
SM-E7000
SM-N9005
GT-N7100
GT-N7105
SM-G530Y
SM-G7105

**Asus:**
ASUS_T00J
ASUS_T00F
ASUS_T00P

**TOSHIBA:**
AT10PE-A

**HTC:**
HTC Butterfly

And test passed on 'HTC Butterfly Android 4.4.2' with this commit